### PR TITLE
fix: Agregar rutas de roles faltantes en urls.py

### DIFF
--- a/apps/backend/backendapi/urls.py
+++ b/apps/backend/backendapi/urls.py
@@ -20,4 +20,7 @@ urlpatterns = [
 
     # URLs MFA
     path("mfa/", include("backendapi.mfa_urls")),
+    
+    # URLs Gestión de Roles
+    path("roles/", include("backendapi.roles.urls")),
 ]


### PR DESCRIPTION
- Registrar path('roles/', include('backendapi.roles.urls'))
- Necesario para que funcionen los endpoints de roles en producción